### PR TITLE
Handle filter

### DIFF
--- a/controllers/streamingResponseAzureController.js
+++ b/controllers/streamingResponseAzureController.js
@@ -34,24 +34,42 @@ exports.handleStreamingResponseAzure = async (req, res) => {
     // ストリーミングレスポンスをクライアントにパイプする
     response.data.pipe(res);
   } catch (error) {
-    const stream = error.response.data;
+    const errorDetail = await getErrorDetail(error.response.data);
+    res.status(500).send({ error: error.message, detail: errorDetail });
+  }
+};
+
+async function getErrorDetail(errorStream) {
+  return new Promise((resolve, reject) => {
     let body = "";
-    stream.on("data", (chunk) => {
+    const detail = { message: "", innererror: null, code: "" };
+
+    errorStream.on("data", (chunk) => {
       body += chunk.toString();
     });
-    stream.on("end", () => {
+
+    errorStream.on("end", () => {
       try {
         const parsed = JSON.parse(body);
-        console.log("エラーレスポンス（パース済み）:", JSON.stringify(parsed));
-
-        const { message, innererror } = parsed.error || {};
-        console.log("エラーメッセージ:", message);
-        console.log("内部エラー詳細:", JSON.stringify(innererror, null, 2));
-      } catch (err) {
-        console.error("JSONパースエラー:", err.message);
+        console.log("エラーレスポンスBody:", JSON.stringify(parsed));
+        const {
+          message = "",
+          innererror = null,
+          code = "",
+        } = parsed.error || {};
+        detail.message = message;
+        detail.innererror = innererror;
+        detail.code = code;
+        resolve(detail);
+      } catch (e) {
+        console.error("JSONパースエラー:", e.message);
+        reject({ message: "", innererror: null });
       }
     });
 
-    res.status(500).send({ error: error.message });
-  }
-};
+    errorStream.on("error", (e) => {
+      console.error("エラーストリーム処理エラー:", e.message);
+      reject({ message: "", innererror: null });
+    });
+  });
+}

--- a/controllers/streamingResponseAzureController.js
+++ b/controllers/streamingResponseAzureController.js
@@ -34,6 +34,24 @@ exports.handleStreamingResponseAzure = async (req, res) => {
     // ストリーミングレスポンスをクライアントにパイプする
     response.data.pipe(res);
   } catch (error) {
+    const stream = error.response.data;
+    let body = "";
+    stream.on("data", (chunk) => {
+      body += chunk.toString();
+    });
+    stream.on("end", () => {
+      try {
+        const parsed = JSON.parse(body);
+        console.log("エラーレスポンス（パース済み）:", JSON.stringify(parsed));
+
+        const { message, innererror } = parsed.error || {};
+        console.log("エラーメッセージ:", message);
+        console.log("内部エラー詳細:", JSON.stringify(innererror, null, 2));
+      } catch (err) {
+        console.error("JSONパースエラー:", err.message);
+      }
+    });
+
     res.status(500).send({ error: error.message });
   }
 };


### PR DESCRIPTION
# 変更内容
・AzureのAPIからエラー内容を取得し、フィルタリングであることが分かるようにクライアント側に返却する

※`innererror`というオブジェクトが返却され、より詳細な内容が格納されているのですが、なぜかaxiosでやるとnullになりますが、一応取得するロジックは残しています。ここまで詳細な情報を使うことな今のところないと考え、nullになる問題はいったん深掘りせずにいます。
※このコードは今本番環境でもリアルタイムに稼働中です。

# スクリーンショット

# 確認事項

# 備考

---

# マージ後に行うこと
* リモートブランチを削除する
* staging にアップされたら、その旨を Slack で修正内容の確認依頼を出す